### PR TITLE
chore(CI): remove test from update check

### DIFF
--- a/.github/workflows/CHECK_UPDATE.yml
+++ b/.github/workflows/CHECK_UPDATE.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [ 20 ]
+        node-version: [ 24 ]
 
     runs-on: ${{ matrix.os }}
 
@@ -31,8 +31,6 @@ jobs:
           path: camunda-docs
       - name: Update builtins
         run: npm run compile-builtins
-      - name: All
-        run: npm run all
       - name: Create PRs automatically
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:


### PR DESCRIPTION
### Proposed Changes

as we are testing how many builtins are extracted the ci check doesn't run completly if new builtins are present. this action doesn't need to test the change as it only creates a PR which runs the tests again.

See action run: https://github.com/camunda/feel-builtins/actions/runs/19962948913 and its created PR: https://github.com/camunda/feel-builtins/pull/8 (didn't run check because not against main as i run it manually)

Alternatives:
- don't test for exact builtin count
- automaticly update the number 

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->