### PR TITLE
feat: enhance builtins with engine versioning and support for versioned documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ npm run all
 
 # update the built-ins from latest camunda-docs
 npm run update-builtins
+
+# list unique function names introduced after 8.6, prefixed by first version and sorted by version
+npm run list-functions-above-8.6
 ```
 
 ## Related

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "check-types": "tsc --noEmit",
     "update-builtins": "run-s pull-docs compile-builtins",
     "pull-docs": "git -C camunda-docs pull || git clone git@github.com:camunda/camunda-docs.git camunda-docs",
-    "compile-builtins": "node tasks/compileBuiltins.js"
+    "compile-builtins": "node tasks/compileBuiltins.js",
+    "list-functions-above-8.6": "node tasks/listFunctionNamesAboveVersion.js"
   },
   "devDependencies": {
     "@bpmn-io/lezer-feel": "^2.2.1",

--- a/src/camundaBuiltins.js
+++ b/src/camundaBuiltins.js
@@ -10,6 +10,9 @@
  * @typedef { {
  *   name: string,
  *   info: string,
+ *   engines?: {
+ *     camunda?: string;
+ *   },
  *   type?: 'function',
  *   params?: Array<{
  *     name: string;
@@ -25,6 +28,9 @@
 export const feelBuiltins = [
   {
     "name": "not",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -35,6 +41,9 @@ export const feelBuiltins = [
   },
   {
     "name": "get value",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -48,6 +57,9 @@ export const feelBuiltins = [
   },
   {
     "name": "get entries",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -58,6 +70,9 @@ export const feelBuiltins = [
   },
   {
     "name": "context put",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -74,6 +89,9 @@ export const feelBuiltins = [
   },
   {
     "name": "string",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -84,6 +102,9 @@ export const feelBuiltins = [
   },
   {
     "name": "number",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -94,6 +115,9 @@ export const feelBuiltins = [
   },
   {
     "name": "number",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -107,6 +131,9 @@ export const feelBuiltins = [
   },
   {
     "name": "number",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -123,6 +150,9 @@ export const feelBuiltins = [
   },
   {
     "name": "context",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -133,6 +163,9 @@ export const feelBuiltins = [
   },
   {
     "name": "date",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -143,6 +176,9 @@ export const feelBuiltins = [
   },
   {
     "name": "date",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -159,6 +195,9 @@ export const feelBuiltins = [
   },
   {
     "name": "time",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -169,6 +208,9 @@ export const feelBuiltins = [
   },
   {
     "name": "time",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -185,6 +227,9 @@ export const feelBuiltins = [
   },
   {
     "name": "time",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -204,6 +249,9 @@ export const feelBuiltins = [
   },
   {
     "name": "date and time",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -214,6 +262,9 @@ export const feelBuiltins = [
   },
   {
     "name": "date and time",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -227,6 +278,9 @@ export const feelBuiltins = [
   },
   {
     "name": "duration",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -237,6 +291,9 @@ export const feelBuiltins = [
   },
   {
     "name": "years and months duration",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -250,6 +307,9 @@ export const feelBuiltins = [
   },
   {
     "name": "from json",
+    "engines": {
+      "camunda": ">=8.9"
+    },
     "type": "function",
     "params": [
       {
@@ -260,6 +320,9 @@ export const feelBuiltins = [
   },
   {
     "name": "to json",
+    "engines": {
+      "camunda": ">=8.9"
+    },
     "type": "function",
     "params": [
       {
@@ -270,6 +333,9 @@ export const feelBuiltins = [
   },
   {
     "name": "list contains",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -283,6 +349,9 @@ export const feelBuiltins = [
   },
   {
     "name": "count",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -293,6 +362,9 @@ export const feelBuiltins = [
   },
   {
     "name": "min",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -303,6 +375,9 @@ export const feelBuiltins = [
   },
   {
     "name": "max",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -313,6 +388,9 @@ export const feelBuiltins = [
   },
   {
     "name": "sum",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -323,6 +401,9 @@ export const feelBuiltins = [
   },
   {
     "name": "product",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -333,6 +414,9 @@ export const feelBuiltins = [
   },
   {
     "name": "mean",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -343,6 +427,9 @@ export const feelBuiltins = [
   },
   {
     "name": "median",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -353,6 +440,9 @@ export const feelBuiltins = [
   },
   {
     "name": "stddev",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -363,6 +453,9 @@ export const feelBuiltins = [
   },
   {
     "name": "mode",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -373,6 +466,9 @@ export const feelBuiltins = [
   },
   {
     "name": "all",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -383,6 +479,9 @@ export const feelBuiltins = [
   },
   {
     "name": "any",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -393,6 +492,9 @@ export const feelBuiltins = [
   },
   {
     "name": "sublist",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -406,6 +508,9 @@ export const feelBuiltins = [
   },
   {
     "name": "sublist",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -422,6 +527,9 @@ export const feelBuiltins = [
   },
   {
     "name": "append",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -435,6 +543,9 @@ export const feelBuiltins = [
   },
   {
     "name": "concatenate",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -445,6 +556,9 @@ export const feelBuiltins = [
   },
   {
     "name": "insert before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -461,6 +575,9 @@ export const feelBuiltins = [
   },
   {
     "name": "remove",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -474,6 +591,9 @@ export const feelBuiltins = [
   },
   {
     "name": "reverse",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -484,6 +604,9 @@ export const feelBuiltins = [
   },
   {
     "name": "index of",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -497,6 +620,9 @@ export const feelBuiltins = [
   },
   {
     "name": "union",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -507,6 +633,9 @@ export const feelBuiltins = [
   },
   {
     "name": "distinct values",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -517,6 +646,9 @@ export const feelBuiltins = [
   },
   {
     "name": "flatten",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -527,6 +659,9 @@ export const feelBuiltins = [
   },
   {
     "name": "sort",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -540,6 +675,9 @@ export const feelBuiltins = [
   },
   {
     "name": "string join",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -550,6 +688,9 @@ export const feelBuiltins = [
   },
   {
     "name": "string join",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -563,6 +704,9 @@ export const feelBuiltins = [
   },
   {
     "name": "decimal",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -576,6 +720,9 @@ export const feelBuiltins = [
   },
   {
     "name": "floor",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -586,6 +733,9 @@ export const feelBuiltins = [
   },
   {
     "name": "floor",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -599,6 +749,9 @@ export const feelBuiltins = [
   },
   {
     "name": "ceiling",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -609,6 +762,9 @@ export const feelBuiltins = [
   },
   {
     "name": "ceiling",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -622,6 +778,9 @@ export const feelBuiltins = [
   },
   {
     "name": "round up",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -635,6 +794,9 @@ export const feelBuiltins = [
   },
   {
     "name": "round down",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -648,6 +810,9 @@ export const feelBuiltins = [
   },
   {
     "name": "round half up",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -661,6 +826,9 @@ export const feelBuiltins = [
   },
   {
     "name": "round half down",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -674,6 +842,9 @@ export const feelBuiltins = [
   },
   {
     "name": "abs",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -684,6 +855,9 @@ export const feelBuiltins = [
   },
   {
     "name": "modulo",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -697,6 +871,9 @@ export const feelBuiltins = [
   },
   {
     "name": "sqrt",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -707,6 +884,9 @@ export const feelBuiltins = [
   },
   {
     "name": "log",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -717,6 +897,9 @@ export const feelBuiltins = [
   },
   {
     "name": "exp",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -727,6 +910,9 @@ export const feelBuiltins = [
   },
   {
     "name": "odd",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -737,6 +923,9 @@ export const feelBuiltins = [
   },
   {
     "name": "even",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -747,6 +936,9 @@ export const feelBuiltins = [
   },
   {
     "name": "before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -760,6 +952,9 @@ export const feelBuiltins = [
   },
   {
     "name": "before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -773,6 +968,9 @@ export const feelBuiltins = [
   },
   {
     "name": "before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -786,6 +984,9 @@ export const feelBuiltins = [
   },
   {
     "name": "before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -799,6 +1000,9 @@ export const feelBuiltins = [
   },
   {
     "name": "after",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -812,6 +1016,9 @@ export const feelBuiltins = [
   },
   {
     "name": "after",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -825,6 +1032,9 @@ export const feelBuiltins = [
   },
   {
     "name": "after",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -838,6 +1048,9 @@ export const feelBuiltins = [
   },
   {
     "name": "after",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -851,6 +1064,9 @@ export const feelBuiltins = [
   },
   {
     "name": "meets",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -864,6 +1080,9 @@ export const feelBuiltins = [
   },
   {
     "name": "met by",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -877,6 +1096,9 @@ export const feelBuiltins = [
   },
   {
     "name": "overlaps",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -890,6 +1112,9 @@ export const feelBuiltins = [
   },
   {
     "name": "overlaps before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -903,6 +1128,9 @@ export const feelBuiltins = [
   },
   {
     "name": "overlaps after",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -916,6 +1144,9 @@ export const feelBuiltins = [
   },
   {
     "name": "finishes",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -929,6 +1160,9 @@ export const feelBuiltins = [
   },
   {
     "name": "finishes",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -942,6 +1176,9 @@ export const feelBuiltins = [
   },
   {
     "name": "finished by",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -955,6 +1192,9 @@ export const feelBuiltins = [
   },
   {
     "name": "finished by",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -968,6 +1208,9 @@ export const feelBuiltins = [
   },
   {
     "name": "includes",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -981,6 +1224,9 @@ export const feelBuiltins = [
   },
   {
     "name": "includes",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -994,6 +1240,9 @@ export const feelBuiltins = [
   },
   {
     "name": "during",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1007,6 +1256,9 @@ export const feelBuiltins = [
   },
   {
     "name": "during",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1020,6 +1272,9 @@ export const feelBuiltins = [
   },
   {
     "name": "starts",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1033,6 +1288,9 @@ export const feelBuiltins = [
   },
   {
     "name": "starts",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1046,6 +1304,9 @@ export const feelBuiltins = [
   },
   {
     "name": "started by",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1059,6 +1320,9 @@ export const feelBuiltins = [
   },
   {
     "name": "started by",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1072,6 +1336,9 @@ export const feelBuiltins = [
   },
   {
     "name": "coincides",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1085,6 +1352,9 @@ export const feelBuiltins = [
   },
   {
     "name": "coincides",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1098,6 +1368,9 @@ export const feelBuiltins = [
   },
   {
     "name": "substring",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1111,6 +1384,9 @@ export const feelBuiltins = [
   },
   {
     "name": "substring",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1127,6 +1403,9 @@ export const feelBuiltins = [
   },
   {
     "name": "string length",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1137,6 +1416,9 @@ export const feelBuiltins = [
   },
   {
     "name": "upper case",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1147,6 +1429,9 @@ export const feelBuiltins = [
   },
   {
     "name": "lower case",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1157,6 +1442,9 @@ export const feelBuiltins = [
   },
   {
     "name": "substring before",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1170,6 +1458,9 @@ export const feelBuiltins = [
   },
   {
     "name": "substring after",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1183,6 +1474,9 @@ export const feelBuiltins = [
   },
   {
     "name": "contains",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1196,6 +1490,9 @@ export const feelBuiltins = [
   },
   {
     "name": "starts with",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1209,6 +1506,9 @@ export const feelBuiltins = [
   },
   {
     "name": "ends with",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1222,6 +1522,9 @@ export const feelBuiltins = [
   },
   {
     "name": "matches",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1235,6 +1538,9 @@ export const feelBuiltins = [
   },
   {
     "name": "matches",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1251,6 +1557,9 @@ export const feelBuiltins = [
   },
   {
     "name": "replace",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1267,6 +1576,9 @@ export const feelBuiltins = [
   },
   {
     "name": "replace",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1286,6 +1598,9 @@ export const feelBuiltins = [
   },
   {
     "name": "split",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1299,18 +1614,27 @@ export const feelBuiltins = [
   },
   {
     "name": "now",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [],
     "info": "<p>Returns the current date and time including the timezone.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class=\"language-feel\">now(): date and time\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class=\"language-feel\">now()\n// date and time(&quot;2020-07-31T14:27:30@Europe/Berlin&quot;)\n</code></pre>\n"
   },
   {
     "name": "today",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [],
     "info": "<p>Returns the current date.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class=\"language-feel\">today(): date\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class=\"language-feel\">today()\n// date(&quot;2020-07-31&quot;)\n</code></pre>\n"
   },
   {
     "name": "day of week",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1321,6 +1645,9 @@ export const feelBuiltins = [
   },
   {
     "name": "day of year",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1331,6 +1658,9 @@ export const feelBuiltins = [
   },
   {
     "name": "week of year",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1341,6 +1671,9 @@ export const feelBuiltins = [
   },
   {
     "name": "month of year",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1351,6 +1684,9 @@ export const feelBuiltins = [
   },
   {
     "name": "abs",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1369,6 +1705,9 @@ export const feelBuiltins = [
 export const camundaExtensions = [
   {
     "name": "is defined",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1379,6 +1718,9 @@ export const camundaExtensions = [
   },
   {
     "name": "get or else",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1392,6 +1734,9 @@ export const camundaExtensions = [
   },
   {
     "name": "assert",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1405,6 +1750,9 @@ export const camundaExtensions = [
   },
   {
     "name": "assert",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1421,6 +1769,9 @@ export const camundaExtensions = [
   },
   {
     "name": "get value",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1434,6 +1785,9 @@ export const camundaExtensions = [
   },
   {
     "name": "context put",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1450,6 +1804,9 @@ export const camundaExtensions = [
   },
   {
     "name": "context merge",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1460,6 +1817,9 @@ export const camundaExtensions = [
   },
   {
     "name": "date and time",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1473,6 +1833,9 @@ export const camundaExtensions = [
   },
   {
     "name": "duplicate values",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1483,6 +1846,9 @@ export const camundaExtensions = [
   },
   {
     "name": "string join",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1502,6 +1868,9 @@ export const camundaExtensions = [
   },
   {
     "name": "is empty",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1512,6 +1881,9 @@ export const camundaExtensions = [
   },
   {
     "name": "partition",
+    "engines": {
+      "camunda": ">=8.7"
+    },
     "type": "function",
     "params": [
       {
@@ -1525,6 +1897,9 @@ export const camundaExtensions = [
   },
   {
     "name": "fromAi",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -1535,6 +1910,9 @@ export const camundaExtensions = [
   },
   {
     "name": "fromAi",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -1548,6 +1926,9 @@ export const camundaExtensions = [
   },
   {
     "name": "fromAi",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -1564,6 +1945,9 @@ export const camundaExtensions = [
   },
   {
     "name": "fromAi",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -1583,6 +1967,9 @@ export const camundaExtensions = [
   },
   {
     "name": "fromAi",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -1605,12 +1992,18 @@ export const camundaExtensions = [
   },
   {
     "name": "random number",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [],
     "info": "<p><em>Camunda Extension</em></p>\n<p>Returns a random number between <code>0</code> and <code>1</code>.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class=\"language-feel\">random number(): number\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class=\"language-feel\">random number()\n// 0.9701618132579795\n</code></pre>\n"
   },
   {
     "name": "extract",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1624,6 +2017,9 @@ export const camundaExtensions = [
   },
   {
     "name": "trim",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1634,12 +2030,18 @@ export const camundaExtensions = [
   },
   {
     "name": "uuid",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [],
     "info": "<p><em>Camunda Extension</em></p>\n<p>Returns a UUID (Universally Unique Identifier) with 36 characters.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class=\"language-feel\">uuid(): string\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class=\"language-feel\">uuid()\n// &quot;7793aab1-d761-4d38-916b-b7270e309894&quot;\n</code></pre>\n"
   },
   {
     "name": "to base64",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1650,6 +2052,9 @@ export const camundaExtensions = [
   },
   {
     "name": "is blank",
+    "engines": {
+      "camunda": ">=8.8"
+    },
     "type": "function",
     "params": [
       {
@@ -1660,6 +2065,9 @@ export const camundaExtensions = [
   },
   {
     "name": "last day of month",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {
@@ -1685,6 +2093,9 @@ export const camundaBuiltins = [ ...feelBuiltins, ...camundaExtensions ];
 export const camundaReservedNameBuiltins = [
   {
     "name": "get or else",
+    "engines": {
+      "camunda": ">=8.6"
+    },
     "type": "function",
     "params": [
       {

--- a/tasks/camundaBuiltins.template.js
+++ b/tasks/camundaBuiltins.template.js
@@ -10,6 +10,9 @@
  * @typedef { {
  *   name: string,
  *   info: string,
+ *   engines?: {
+ *     camunda?: string;
+ *   },
  *   type?: 'function',
  *   params?: Array<{
  *     name: string;

--- a/tasks/compileBuiltins.js
+++ b/tasks/compileBuiltins.js
@@ -1,17 +1,28 @@
 import { glob } from 'glob';
+import { readFile } from 'node:fs/promises';
 import { categorizeBuiltins, logStatistics, parseBuiltins, parseMarkdownFile, writeBuiltinsFromTemplate } from './utils/index.js';
 
 // paths relative to CWD
 const MARKDOWN_SRC = './camunda-docs/docs/components/modeler/feel/builtin-functions/*.md';
+const VERSIONED_MARKDOWN_SRC = './camunda-docs/versioned_docs/version-*/components/modeler/feel/builtin-functions/*.md';
+const DOCS_VERSIONS_SRC = './camunda-docs/versions.json';
 const JS_SRC = './tasks/camundaBuiltins.template.js';
 const JS_DEST = './src/camundaBuiltins.js';
 
 async function run() {
-  const files = await glob(MARKDOWN_SRC);
+  const currentDocsVersion = await getCurrentDocsVersion();
+  const [ files, versionedFiles ] = await Promise.all([
+    glob(MARKDOWN_SRC),
+    glob(VERSIONED_MARKDOWN_SRC)
+  ]);
 
-  const descriptors = (await Promise.all(files.sort().map(parseMarkdownFile))).flat();
+  const [ descriptors, versionedDescriptors ] = await Promise.all([
+    Promise.all(files.sort().map((file) => parseMarkdownFile(file, currentDocsVersion))),
+    Promise.all(versionedFiles.sort().map((file) => parseMarkdownFile(file)))
+  ]);
 
-  const builtins = parseBuiltins(descriptors);
+  const currentDescriptors = descriptors.flat();
+  const builtins = parseBuiltins(currentDescriptors, [ ...currentDescriptors, ...versionedDescriptors.flat() ]);
 
   // Categorize into FEEL builtins and Camunda extensions
   const categorized = categorizeBuiltins(builtins);
@@ -26,3 +37,36 @@ run().catch((err) => {
 
   process.exit(1);
 });
+
+async function getCurrentDocsVersion() {
+  const versions = JSON.parse(await readFile(DOCS_VERSIONS_SRC, 'utf-8'));
+
+  if (!Array.isArray(versions) || !versions.length) {
+    throw new Error(`failed to determine current docs version from <${DOCS_VERSIONS_SRC}>`);
+  }
+
+  const latestVersion = versions
+    .map(parseVersion)
+    .sort(compareVersionParts)
+    .at(-1);
+
+  if (!latestVersion) {
+    throw new Error(`failed to parse versions from <${DOCS_VERSIONS_SRC}>`);
+  }
+
+  return `${latestVersion[0]}.${latestVersion[1] + 1}`;
+}
+
+function parseVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)$/);
+
+  if (!match) {
+    throw new Error(`failed to parse docs version <${version}>`);
+  }
+
+  return [ Number(match[1]), Number(match[2]) ];
+}
+
+function compareVersionParts(left, right) {
+  return left[0] - right[0] || left[1] - right[1];
+}

--- a/tasks/compileBuiltins.js
+++ b/tasks/compileBuiltins.js
@@ -21,8 +21,9 @@ async function run() {
     Promise.all(versionedFiles.sort().map((file) => parseMarkdownFile(file)))
   ]);
 
-  const currentDescriptors = descriptors.flat();
-  const builtins = parseBuiltins(currentDescriptors, [ ...currentDescriptors, ...versionedDescriptors.flat() ]);
+  const currentDescriptors = descriptors.reduce(flattenDescriptors, []);
+  const supportedDescriptors = currentDescriptors.concat(versionedDescriptors.reduce(flattenDescriptors, []));
+  const builtins = parseBuiltins(currentDescriptors, supportedDescriptors);
 
   // Categorize into FEEL builtins and Camunda extensions
   const categorized = categorizeBuiltins(builtins);
@@ -39,16 +40,19 @@ run().catch((err) => {
 });
 
 async function getCurrentDocsVersion() {
+
+  /** @type {string[]} */
   const versions = JSON.parse(await readFile(DOCS_VERSIONS_SRC, 'utf-8'));
 
   if (!Array.isArray(versions) || !versions.length) {
     throw new Error(`failed to determine current docs version from <${DOCS_VERSIONS_SRC}>`);
   }
 
-  const latestVersion = versions
+  /** @type {[number, number][]} */
+  const sortedVersions = versions
     .map(parseVersion)
-    .sort(compareVersionParts)
-    .at(-1);
+    .sort(compareVersionParts);
+  const latestVersion = sortedVersions[sortedVersions.length - 1];
 
   if (!latestVersion) {
     throw new Error(`failed to parse versions from <${DOCS_VERSIONS_SRC}>`);
@@ -57,6 +61,10 @@ async function getCurrentDocsVersion() {
   return `${latestVersion[0]}.${latestVersion[1] + 1}`;
 }
 
+/**
+ * @param {string} version
+ * @returns {[number, number]}
+ */
 function parseVersion(version) {
   const match = version.match(/^(\d+)\.(\d+)$/);
 
@@ -67,6 +75,18 @@ function parseVersion(version) {
   return [ Number(match[1]), Number(match[2]) ];
 }
 
+/**
+ * @param {[number, number]} left
+ * @param {[number, number]} right
+ */
 function compareVersionParts(left, right) {
   return left[0] - right[0] || left[1] - right[1];
+}
+
+/**
+ * @param {import('./utils/markdownParser.js').BuiltinDescriptor[]} accumulator
+ * @param {import('./utils/markdownParser.js').BuiltinDescriptor[]} descriptors
+ */
+function flattenDescriptors(accumulator, descriptors) {
+  return accumulator.concat(descriptors);
 }

--- a/tasks/listFunctionNamesAboveVersion.js
+++ b/tasks/listFunctionNamesAboveVersion.js
@@ -1,0 +1,70 @@
+import { camundaBuiltins } from '../src/camundaBuiltins.js';
+
+const defaultMinimumVersion = '8.6';
+const minimumVersion = process.argv[2] || defaultMinimumVersion;
+
+const functionsByName = new Map();
+
+for (const builtin of camundaBuiltins) {
+  const engine = getCamundaMinimumVersion(builtin);
+
+  if (!engine || compareVersions(engine, minimumVersion) <= 0) {
+    continue;
+  }
+
+  const currentEngine = functionsByName.get(builtin.name);
+
+  if (!currentEngine || compareVersions(engine, currentEngine) < 0) {
+    functionsByName.set(builtin.name, engine);
+  }
+}
+
+const functions = [ ...functionsByName.entries() ]
+  .sort(([ leftName, leftEngine ], [ rightName, rightEngine ]) => {
+    return compareVersions(leftEngine, rightEngine) || leftName.localeCompare(rightName);
+  });
+
+for (const [ name, engine ] of functions) {
+  console.log(`${engine} ${name}`);
+}
+
+/**
+ * @param {string} left
+ * @param {string} right
+ * @returns {number}
+ */
+function compareVersions(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < maxLength; index++) {
+    const difference = (leftParts[index] || 0) - (rightParts[index] || 0);
+
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * @param {{ engines?: { camunda?: string } }} builtin
+ * @returns {string|undefined}
+ */
+function getCamundaMinimumVersion(builtin) {
+  const versionRange = builtin.engines?.camunda;
+
+  if (!versionRange) {
+    return;
+  }
+
+  const match = versionRange.match(/^>=\s*(\d+(?:\.\d+)*)$/);
+
+  if (!match) {
+    throw new Error(`unsupported Camunda engine range <${versionRange}>`);
+  }
+
+  return match[1];
+}

--- a/tasks/listFunctionNamesAboveVersion.js
+++ b/tasks/listFunctionNamesAboveVersion.js
@@ -19,8 +19,11 @@ for (const builtin of camundaBuiltins) {
   }
 }
 
-const functions = [ ...functionsByName.entries() ]
-  .sort(([ leftName, leftEngine ], [ rightName, rightEngine ]) => {
+const functions = Array.from(functionsByName.entries())
+  .sort((leftEntry, rightEntry) => {
+    const [ leftName, leftEngine ] = leftEntry;
+    const [ rightName, rightEngine ] = rightEntry;
+
     return compareVersions(leftEngine, rightEngine) || leftName.localeCompare(rightName);
   });
 

--- a/tasks/utils/markdownParser.js
+++ b/tasks/utils/markdownParser.js
@@ -20,7 +20,9 @@ export async function parseMarkdownFile(fileName, currentVersion) {
   const [ _heading, ...contents ] = fileContent.split('## ');
 
   const descriptions = await Promise.all(
-    contents.flatMap(async (string) => {
+    contents.map(async (
+        /** @type {string} */ string
+    ) => {
       const name = string.split('\n')[0];
       let description = await Promise.resolve(marked.parse(string.split('\n').slice(1).join('\n')));
 

--- a/tasks/utils/markdownParser.js
+++ b/tasks/utils/markdownParser.js
@@ -2,16 +2,20 @@ import { marked } from 'marked';
 import { readFile } from 'node:fs/promises';
 
 /**
- * @typedef { { name: string, description: string } } BuiltinDescriptor
+ * @typedef { { name: string, description: string, engine?: string } } BuiltinDescriptor
  */
+
+const VERSIONED_DOCS_PATH_PATTERN = /\/versioned_docs\/version-(\d+\.\d+)\//;
 
 /**
  * Parse a markdown file to extract builtin function descriptors
  * @param {string} fileName
+ * @param {string} [currentVersion]
  * @return {Promise<BuiltinDescriptor[]>}
  */
-export async function parseMarkdownFile(fileName) {
+export async function parseMarkdownFile(fileName, currentVersion) {
   const fileContent = await readFile(fileName, 'utf-8');
+  const engine = inferEngineVersion(fileName, currentVersion);
 
   const [ _heading, ...contents ] = fileContent.split('## ');
 
@@ -27,9 +31,26 @@ export async function parseMarkdownFile(fileName) {
         throw new Error(`unsupported built-in name <${name}>`);
       }
 
-      return { name, description };
+      return { name, description, engine };
     }),
   );
 
   return descriptions;
+}
+
+/**
+ * @param {string} fileName
+ * @param {string} [currentVersion]
+ * @returns {string|undefined}
+ */
+function inferEngineVersion(fileName, currentVersion) {
+  const versionedDocsMatch = fileName.match(VERSIONED_DOCS_PATH_PATTERN);
+
+  if (versionedDocsMatch) {
+    return versionedDocsMatch[1];
+  }
+
+  if (fileName.includes('/docs/components/modeler/feel/builtin-functions/')) {
+    return currentVersion;
+  }
 }

--- a/tasks/utils/parseBuiltins.js
+++ b/tasks/utils/parseBuiltins.js
@@ -1,18 +1,22 @@
 /**
  * @param { import('./markdownParser.js').BuiltinDescriptor[] } descriptors
+ * @param { import('./markdownParser.js').BuiltinDescriptor[] } [supportedDescriptors]
  *
  * @returns {import('@camunda/feel-builtins').Builtin[] }
  */
-export function parseBuiltins(descriptors) {
-  return descriptors.map(parseBuiltin);
+export function parseBuiltins(descriptors, supportedDescriptors = descriptors) {
+  const earliestSupportedEngines = getEarliestSupportedEngines(supportedDescriptors);
+
+  return descriptors.map((descriptor) => parseBuiltin(descriptor, earliestSupportedEngines.get(descriptor.name)));
 }
 
 /**
  * @param { import('./markdownParser.js').BuiltinDescriptor } descriptor
+ * @param { string } [engine]
  *
  * @returns { import('@camunda/feel-builtins').Builtin }
  */
-export function parseBuiltin(descriptor) {
+export function parseBuiltin(descriptor, engine = descriptor.engine) {
 
   const {
     name,
@@ -33,9 +37,58 @@ export function parseBuiltin(descriptor) {
 
   return {
     name: functionName,
+    ...(engine ? {
+      engines: {
+        camunda: `>=${engine}`
+      }
+    } : {}),
     type: 'function',
     params,
     info: description
   };
+}
+
+/**
+ * @param { import('./markdownParser.js').BuiltinDescriptor[] } descriptors
+ *
+ * @returns { Map<string, string> }
+ */
+function getEarliestSupportedEngines(descriptors) {
+  const earliestSupportedEngines = new Map();
+
+  for (const descriptor of descriptors) {
+    if (!descriptor.engine) {
+      continue;
+    }
+
+    const currentEngine = earliestSupportedEngines.get(descriptor.name);
+
+    if (!currentEngine || compareVersions(descriptor.engine, currentEngine) < 0) {
+      earliestSupportedEngines.set(descriptor.name, descriptor.engine);
+    }
+  }
+
+  return earliestSupportedEngines;
+}
+
+/**
+ * @param {string} left
+ * @param {string} right
+ * @returns {number}
+ */
+function compareVersions(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < maxLength; index++) {
+    const difference = (leftParts[index] || 0) - (rightParts[index] || 0);
+
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
 }
 

--- a/test/spec/lib/camundaBuiltins.spec.js
+++ b/test/spec/lib/camundaBuiltins.spec.js
@@ -54,6 +54,9 @@ describe('camundaBuiltins', function() {
     // then
     expectBuiltinProperties(camundaBuiltins, 'get or else', {
       name: 'get or else',
+      engines: {
+        camunda: '>=8.6'
+      },
       type: 'function',
       params: [ { name: 'value' }, { name: 'default' } ],
     });
@@ -65,6 +68,9 @@ describe('camundaBuiltins', function() {
     // then
     expectBuiltinProperties(camundaBuiltins, 'random number', {
       name: 'random number',
+      engines: {
+        camunda: '>=8.6'
+      },
       type: 'function',
       params: []
     });

--- a/test/spec/tasks/utils/parseBuiltins.spec.js
+++ b/test/spec/tasks/utils/parseBuiltins.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { parseBuiltin } from '../../../../tasks/utils/parseBuiltins.js';
+import { parseBuiltin, parseBuiltins } from '../../../../tasks/utils/parseBuiltins.js';
 
 
 describe('tasks/parseBuiltins', function() {
@@ -10,6 +10,7 @@ describe('tasks/parseBuiltins', function() {
     // given
     const descriptor = {
       name: 'get or else(value, default)',
+      engine: '8.6',
       description:
         '<p><em>Camunda Extension</em></p>\n<p>Return the provided value parameter if not <code>null</code>, otherwise return the default parameter</p>\n<p><strong>Function signature</strong></p>\n<pre><code class="language-feel">get or else(value: Any, default: Any): Any\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class="language-feel">get or else(&quot;this&quot;, &quot;default&quot;)\n// &quot;this&quot;\n\nget or else(null, &quot;default&quot;)\n// &quot;default&quot;\n\nget or else(null, null)\n// null\n</code></pre>\n',
     };
@@ -20,6 +21,9 @@ describe('tasks/parseBuiltins', function() {
     // then
     expect(builtin).to.eql({
       name: 'get or else',
+      engines: {
+        camunda: '>=8.6'
+      },
       info: descriptor.description,
       type: 'function',
       params: [
@@ -39,6 +43,7 @@ describe('tasks/parseBuiltins', function() {
     // given
     const descriptor = {
       name: 'random number()',
+      engine: '8.7',
       description:
         '<p><em>Camunda Extension</em></p>\n<p>Returns a random number between <code>0</code> and <code>1</code>.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class="language-feel">random number(): number\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class="language-feel">random number()\n// 0.9701618132579795\n</code></pre>\n',
     };
@@ -49,9 +54,42 @@ describe('tasks/parseBuiltins', function() {
     // then
     expect(builtin).to.eql({
       name: 'random number',
+      engines: {
+        camunda: '>=8.7'
+      },
       info: descriptor.description,
       type: 'function',
       params: [],
+    });
+  });
+
+
+  it('should use the first supported engine version', function() {
+
+    // given
+    const currentDescriptors = [ {
+      name: 'fromAi(value)',
+      engine: '8.9',
+      description: '<p><em>Camunda Extension</em></p>'
+    } ];
+    const allDescriptors = [
+      ...currentDescriptors,
+      {
+        name: 'fromAi(value)',
+        engine: '8.8',
+        description: '<p><em>Camunda Extension</em></p>'
+      }
+    ];
+
+    // when
+    const [ builtin ] = parseBuiltins(currentDescriptors, allDescriptors);
+
+    // then
+    expect(builtin).to.deep.include({
+      name: 'fromAi',
+      engines: {
+        camunda: '>=8.8'
+      }
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "compilerOptions": {
     "lib": [
-      "ES2018"
+      "ES2019"
     ],
     "strict": true,
     "checkJs": true,
+    "noEmit": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "types": [
+      "node",
+      "mocha"
+    ],
     "skipLibCheck": true
   },
   "include": [


### PR DESCRIPTION
> [!NOTE]
> AI generated implementation and PR

- Added optional engine versioning to builtins in camundaBuiltins.template.js.
- Updated compileBuiltins.js to handle versioned markdown files and determine the current documentation version.
- Modified markdownParser.js to infer engine versions from file names and added support for current version parameter.
- Enhanced parseBuiltins.js to utilize the earliest supported engine version for each builtin.
- Updated tests to validate engine versioning for builtins.
- Introduced a new script to list function names above a specified engine version.

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->