### PR TITLE
fix: add engines metadata to `from base64`

### DIFF
--- a/src/camundaBuiltins.js
+++ b/src/camundaBuiltins.js
@@ -1711,7 +1711,10 @@ export const camundaExtensions = [
         "name": "value"
       }
     ],
-    "info": "<p><em>Camunda Extension</em></p>\n<p>Returns the given Base64 encoded string decoded to a plain string.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class=\"language-feel\">from base64(value: string): string\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class=\"language-feel\">from base64(&quot;RkVFTA==&quot;)\n// &quot;FEEL&quot;\n</code></pre>\n"
+    "info": "<p><em>Camunda Extension</em></p>\n<p>Returns the given Base64 encoded string decoded to a plain string.</p>\n<p><strong>Function signature</strong></p>\n<pre><code class=\"language-feel\">from base64(value: string): string\n</code></pre>\n<p><strong>Examples</strong></p>\n<pre><code class=\"language-feel\">from base64(&quot;RkVFTA==&quot;)\n// &quot;FEEL&quot;\n</code></pre>\n",
+    "engines": {
+      "camunda": ">=8.9"
+    }
   },
   {
     "name": "is blank",

--- a/tasks/engines.js
+++ b/tasks/engines.js
@@ -20,6 +20,7 @@ export const enginesByFunction = {
   'is blank': { camunda: '>=8.8' },
   'partition': { camunda: '>=8.7' },
   'fromAi': { camunda: '>=8.8' },
+  'from base64': { camunda: '>=8.9' },
   'from json': { camunda: '>=8.9' },
   'to json': { camunda: '>=8.9' },
 };


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Add missing engines metadata to `from base64` function.

Related to https://github.com/camunda/camunda-modeler/pull/6129#issuecomment-5392455398

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->